### PR TITLE
Update 2019.03.05

### DIFF
--- a/disklocation-devel.plg
+++ b/disklocation-devel.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2019.02.18b-dev">
+<!ENTITY version          "2019.03.05-dev">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY packageGIT       "https://github.com/olehj/disklocation.git">
 <!ENTITY branch           "devel">

--- a/disklocation-master.plg
+++ b/disklocation-master.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2019.02.18b">
+<!ENTITY version          "2019.03.05">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY packageGIT       "https://github.com/olehj/disklocation.git">
 <!ENTITY branch           "master">
@@ -24,6 +24,7 @@
          version="&version;"
          launch="&launch;"
          pluginURL="&pluginURL;"
+	 min="6.6.0"
 	 support="&pluginsupportURL;"
 >
 
@@ -38,6 +39,9 @@
 </FILE>
 
 <CHANGES>
+###2019.03.05
+ - Updated the installer script to accept installations for Unraid 6.6.0 and above as earlier version does not support UPSERT in SQLite.
+
 ###2019.02.18b
  - Commit #53 - MINOR ISSUE: Found the actual line, checks for disksize value before calculating human readable size.
 

--- a/disklocation.plg
+++ b/disklocation.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2019.02.18b">
+<!ENTITY version          "2019.03.05">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY packageGIT       "https://github.com/olehj/disklocation.git">
 <!ENTITY branch           "master">
@@ -24,6 +24,7 @@
          version="&version;"
          launch="&launch;"
          pluginURL="&pluginURL;"
+	 min="6.6.0"
 	 support="&pluginsupportURL;"
 >
 
@@ -38,6 +39,9 @@
 </FILE>
 
 <CHANGES>
+###2019.03.05
+ - Updated the installer script to accept installations for Unraid 6.6.0 and above as earlier version does not support UPSERT in SQLite.
+
 ###2019.02.18b
  - Commit #53 - MINOR ISSUE: Found the actual line, checks for disksize value before calculating human readable size.
 


### PR DESCRIPTION
Changed the installer to install only on Unraid 6.6.0 and above due to SQLite restrictions on earlier versions.