### PR TITLE
Fixes #72

### DIFF
--- a/disklocation-devel.plg
+++ b/disklocation-devel.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2019.05.21b-dev">
+<!ENTITY version          "2019.05.23-dev">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY packageGIT       "https://github.com/olehj/disklocation.git">
 <!ENTITY branch           "devel">
@@ -12,10 +12,6 @@
 <!ENTITY pluginLOC        "/boot/config/plugins/&name;">
 <!ENTITY emplugLOC        "/usr/local/emhttp/plugins">
 <!ENTITY emhttpLOC        "&emplugLOC;/&name;">
-<!ENTITY smartmontools    "smartmontools-7.0-x86_64-1.txz">
-<!ENTITY smartmontoolsMD5 "c5c852915332cd0984b040eeb545c43c">
-<!ENTITY gittools         "git-2.14.5-x86_64-1_slack14.2.txz">
-<!ENTITY gittoolsMD5      "99ab6ab1d4685a81252893db01d63c5a">
 <!ENTITY pluginsupportURL "https://forums.unraid.net/topic/77302-plugin-disk-location/">
 ]>
 
@@ -27,14 +23,19 @@
 	 support="&pluginsupportURL;"
 >
 
-<FILE Name="/boot/packages/&smartmontools;" Run="upgradepkg --install-new" Max="6.6.9">
-<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/a/&smartmontools;</URL>
-<MD5>&smartmontoolsMD5;</MD5>
+<FILE Name="/boot/packages/smartmontools-7.0-x86_64-1.txz" Run="upgradepkg --install-new" Max="6.6.9">
+<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/a/smartmontools-7.0-x86_64-1.txz</URL>
+<MD5>c5c852915332cd0984b040eeb545c43c</MD5>
 </FILE>
 
-<FILE Name="/boot/packages/&gittools;" Run="upgradepkg --install-new" Max="6.6.9">
-<URL>http://mirrors.slackware.com/slackware/slackware64-14.2/patches/packages/&gittools;</URL>
-<MD5>&gittoolsMD5;</MD5>
+<FILE Name="/boot/packages/git-2.14.5-x86_64-1_slack14.2.txz" Run="upgradepkg --install-new" Max="6.6.9">
+<URL>http://mirrors.slackware.com/slackware/slackware64-14.2/patches/packages/git-2.14.5-x86_64-1_slack14.2.txz</URL>
+<MD5>99ab6ab1d4685a81252893db01d63c5a</MD5>
+</FILE>
+
+<FILE Name="/boot/packages/git-2.21.0-x86_64-1.txz" Run="upgradepkg --install-new" Min="6.7.0" Max="6.7.1">
+<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/d/git-2.21.0-x86_64-1.txz</URL>
+<MD5>2f581b9d083b2a4e9c92255b5ea2eb26</MD5>
 </FILE>
 
 <CHANGES>

--- a/disklocation-master.plg
+++ b/disklocation-master.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2019.05.21">
+<!ENTITY version          "2019.05.23">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY packageGIT       "https://github.com/olehj/disklocation.git">
 <!ENTITY branch           "master">
@@ -12,10 +12,6 @@
 <!ENTITY pluginLOC        "/boot/config/plugins/&name;">
 <!ENTITY emplugLOC        "/usr/local/emhttp/plugins">
 <!ENTITY emhttpLOC        "&emplugLOC;/&name;">
-<!ENTITY smartmontools    "smartmontools-7.0-x86_64-1.txz">
-<!ENTITY smartmontoolsMD5 "c5c852915332cd0984b040eeb545c43c">
-<!ENTITY gittools         "git-2.14.5-x86_64-1_slack14.2.txz">
-<!ENTITY gittoolsMD5      "99ab6ab1d4685a81252893db01d63c5a">
 <!ENTITY pluginsupportURL "https://forums.unraid.net/topic/77302-plugin-disk-location/">
 ]>
 
@@ -28,17 +24,25 @@
 	 support="&pluginsupportURL;"
 >
 
-<FILE Name="/boot/packages/&smartmontools;" Run="upgradepkg --install-new" Max="6.6.9">
-<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/a/&smartmontools;</URL>
-<MD5>&smartmontoolsMD5;</MD5>
+<FILE Name="/boot/packages/smartmontools-7.0-x86_64-1.txz" Run="upgradepkg --install-new" Max="6.6.9">
+<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/a/smartmontools-7.0-x86_64-1.txz</URL>
+<MD5>c5c852915332cd0984b040eeb545c43c</MD5>
 </FILE>
 
-<FILE Name="/boot/packages/&gittools;" Run="upgradepkg --install-new" Max="6.6.9">
-<URL>http://mirrors.slackware.com/slackware/slackware64-14.2/patches/packages/&gittools;</URL>
-<MD5>&gittoolsMD5;</MD5>
+<FILE Name="/boot/packages/git-2.14.5-x86_64-1_slack14.2.txz" Run="upgradepkg --install-new" Max="6.6.9">
+<URL>http://mirrors.slackware.com/slackware/slackware64-14.2/patches/packages/git-2.14.5-x86_64-1_slack14.2.txz</URL>
+<MD5>99ab6ab1d4685a81252893db01d63c5a</MD5>
+</FILE>
+
+<FILE Name="/boot/packages/git-2.21.0-x86_64-1.txz" Run="upgradepkg --install-new" Min="6.7.0" Max="6.7.1">
+<URL>https://mirrors.slackware.com/slackware/slackware64-current/slackware64/d/git-2.21.0-x86_64-1.txz</URL>
+<MD5>2f581b9d083b2a4e9c92255b5ea2eb26</MD5>
 </FILE>
 
 <CHANGES>
+###2019.05.23
+ - Commit #72 - BUG: Blank screen after installing, git not included afterall in 6.7.0/6.7.1-rc1. Will install git with the intended version before installing the plugin.
+
 ###2019.05.21
  - Commit #69 - IMPROVEMENT: Cleared up some UI issues. Made sure that trays can't be written over each other, the newest assigned device will overwrite the existing tray and put the device (if it exists) back in the unassigned table. Also my favorite commit number.
 


### PR DESCRIPTION
Blank screen after installing, git not included afterall in 6.7.0/6.7.1-rc1. Will install git with the intended version before installing the plugin.