### PR TITLE
Update 2023.04.01

### DIFF
--- a/disklocation-devel.plg
+++ b/disklocation-devel.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2023.03.25-dev">
+<!ENTITY version          "2023.04.01-dev">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY branch           "devel">
 <!ENTITY packageURL       "https://github.com/olehj/disklocation/archive/&branch;.zip">

--- a/disklocation-master.plg
+++ b/disklocation-master.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name             "disklocation">
 <!ENTITY author           "Ole-Henrik Jakobsen">
-<!ENTITY version          "2023.03.25">
+<!ENTITY version          "2023.04.01">
 <!ENTITY launch           "Settings/&name;">
 <!ENTITY branch           "master">
 <!ENTITY packageURL       "https://github.com/olehj/disklocation/archive/&branch;.zip">
@@ -21,7 +21,7 @@
          launch="&launch;"
          pluginURL="&pluginURL;"
          icon="server"
-         min="6.11.9"
+         min="6.9.0"
          support="&pluginsupportURL;"
 >
 
@@ -46,6 +46,9 @@
 
 -->
 <CHANGES>
+###2023.04.01
+ - Commit #205 - IMPROVEMENT: Added a legacy dashboard back, as people can use newer plugin on a current stable Unraid system again. -_- Also removed a useless question mark icon when hovering the LED-icons.
+
 ###2023.03.25
  - Commit #203 - BUG: Background color bug if warning/critical flash fixed.
 

--- a/disklocation/disklocation_dashboard-legacy.page
+++ b/disklocation/disklocation_dashboard-legacy.page
@@ -1,0 +1,117 @@
+Cond="version_compare(parse_ini_file('/etc/unraid-version')['version'],'6.11.9','<')"
+Menu="Dashboard"
+Icon="server"
+Tag="server"
+---
+<?php
+	/*
+	 *  Copyright 2019-2023, Ole-Henrik Jakobsen
+	 *
+	 *  This file is part of Disk Location for Unraid.
+	 *
+	 *  Disk Location for Unraid is free software: you can redistribute it and/or modify
+	 *  it under the terms of the GNU General Public License as published by
+	 *  the Free Software Foundation, either version 3 of the License, or
+	 *  (at your option) any later version.
+	 *
+	 *  Disk Location for Unraid is distributed in the hope that it will be useful,
+	 *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 *  GNU General Public License for more details.
+	 *
+	 *  You should have received a copy of the GNU General Public License
+	 *  along with Disk Location for Unraid.  If not, see <https://www.gnu.org/licenses/>.
+	 *
+	 */
+	require_once("/usr/local/emhttp/plugins/disklocation/pages/system.php");
+	require_once("/usr/local/emhttp/plugins/disklocation/pages/devices.php");
+	
+	$sql = "SELECT * FROM settings_group ORDER BY id ASC";
+	$results = $db->query($sql);
+	
+	while($data = $results->fetchArray(1)) {
+		extract($data);
+		$gid = $id;
+		
+		$css_grid_group = "
+			grid-template-columns: " . $grid_columns_styles[$gid] . ";
+			grid-template-rows: " . $grid_rows_styles[$gid] . ";
+			grid-auto-flow: " . $grid_count . ";
+		";
+		
+		$disklocation_dash_out .= "
+			<div style=\"float: left; padding: 5px 10px 5px 10px;\">
+				<div style=\"text-align: center;\"><b>" . stripslashes(htmlspecialchars($group_name)) . "</b></div>
+				<div class=\"grid-container\" style=\"$css_grid_group\">
+					$disklocation_dash[$gid]
+				</div>
+			</div>
+		";
+		$i++;
+	}
+	if(is_array($installed_drives)) {
+		$installed_drives = array_sum($installed_drives);
+	}
+	else {
+		$installed_drives = 0;
+	}
+	
+	$dashboard_widget_pos_legacy = 2;
+	$dashboard_widget_colspan_legacy = 5;
+	/* Disabled the positions as they are incompatible with the new Unraid 6.12 version of the plugin. This will also make some people happy hopefully.. but I dunno, maybe not. Because suddenly it will be stuck on the right side of the dashboard regardless. It can't be disabled either, soooo... the next forum posts might be interessting, I don't know.. but best I can do for now. At least you can still move it up and down. Yes, I'm a bit bored writing all this nonsense. But I felt like it, cheers!
+	
+	if($dashboard_widget_pos_legacy == 1) {
+		$dashboard_widget_colspan_legacy = 3;
+	}
+	if($dashboard_widget_pos_legacy == 2) {
+		$dashboard_widget_colspan_legacy = 5;
+	}
+	*/
+?>
+
+<style type="text/css">
+	.dash_disklocation_toggle{display:none}
+</style>
+
+<table id="db-box<?php echo $dashboard_widget_pos_legacy ?>" class="dash_disklocation dashboard box<?php echo $dashboard_widget_pos_legacy ?>" style="display:none">
+	<thead sort="10" class="sortable">
+		<tr>
+			<td></td>
+			<td class="next" colspan="<?php echo $dashboard_widget_colspan_legacy ?>" style="white-space: no-wrap;">Disk Location
+				<i class="fa fa-fw chevron mt0" id="dash_disklocation_toggle" onclick="toggleChevron('dash_disklocation_toggle',0)"></i>
+				<a href="/Settings/disklocationConfig" title="Go to Disk Location Configuration page"><i class="fa fa-fw fa-cog chevron mt0"></i></a>
+				<a href="/Tools/disklocation" title="Go to Disk Location page"><i class="fa fa-fw fa-server chevron mt0"></i></a>
+				<span class="info"><?php print($installed_drives); ?> of <?php print($total_trays_group); ?> drives assigned. <?php //print($dashboard_info); ?></span>
+			</td>
+			<td></td>
+		</tr>
+	</thead>
+	<tbody class="dash_disklocation_toggle sortable" sort="10">
+		<tr>
+			<td></td>
+			<td colspan="<?php echo $dashboard_widget_colspan_legacy ?>" class="top" style="vertical-align: top;">
+				<style type="text/css">
+					<?php require_once("/usr/local/emhttp/plugins/disklocation/pages/styles/disk.css.php"); ?>
+				</style>
+				<link type="text/css" rel="stylesheet" href="<?autov("" . DISKLOCATION_PATH . "/pages/styles/signals.css")?>">
+				<?php print($disklocation_dash_out); ?>
+			</td>
+			<td></td>
+		</tr>
+	</tbody>
+</table>
+
+<script>
+$(function() {
+  // append data from the table into the correct one
+  $("#db-box<?php echo $dashboard_widget_pos_legacy ?>").append($(".dash_disklocation").html());
+  
+  // reload toggle to get the correct state
+  toggleView('dash_disklocation_toggle',true);
+  
+  // reload sorting to get the stored data (cookie)
+  sortTable($('#db-box1'),$.cookie('db-box1'));
+  sortTable($('#db-box2'),$.cookie('db-box2'));
+  sortTable($('#db-box3'),$.cookie('db-box3'));
+});
+</script>

--- a/disklocation/disklocation_dashboard.page
+++ b/disklocation/disklocation_dashboard.page
@@ -1,5 +1,5 @@
-Menu="Dashboard:0"
 Cond="version_compare(parse_ini_file('/etc/unraid-version')['version'],'6.11.9','>')"
+Menu="Dashboard:0"
 ---
 <?php
 	/*

--- a/disklocation/pages/styles/signals.css
+++ b/disklocation/pages/styles/signals.css
@@ -2,7 +2,6 @@
 		font-size: 1.1rem;
 		margin: 0;
 		padding: 0 0 0 0;
-		cursor: help;
 	}
 	.grey-orb { color: #C0C0C0 }
 	.grey-off {


### PR DESCRIPTION
Not April Fools, really. But legacy dashboard is back.. however, it's stuck on the right side and enabled by default without the possibility to turn it off. Deal with it. (Only valid for Unraid below version 6.12).